### PR TITLE
feat: Adapting inferFairLevel to deal with file uploading 

### DIFF
--- a/run_development.sh
+++ b/run_development.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+docker build -t imaging-plaza-webapp -f tools/image/Dockerfile .
 
 # Start Docker container in interactive mode
-sudo docker run -it -v "$(pwd)/src/imaging-plaza-webapp":/app -p 3000:3000 --env-file .env --entrypoint /bin/sh imaging-plaza-webapp -c "
+docker run -it -v "$(pwd)/src/imaging-plaza-webapp":/app -p 3000:3000 --env-file .env --entrypoint /bin/sh imaging-plaza-webapp -c "
     npm install &&
     npx browserslist@latest --update-db --yes &&
     npm run build &&


### PR DESCRIPTION
I adapted the fetch method in Infra to be compatible with the new `shacl-api`. 


I also adapted the `run_development.sh` to avoid using sudo which was leading to some errors. It can still be used as `sudo run_development.sh`